### PR TITLE
Teach PPPoE parser about RFC 4638

### DIFF
--- a/print-pppoe.c
+++ b/print-pppoe.c
@@ -70,6 +70,7 @@ enum {
 	PPPOE_AC_COOKIE = 0x0104,
 	PPPOE_VENDOR = 0x0105,
 	PPPOE_RELAY_SID = 0x0110,
+	PPPOE_MAX_PAYLOAD = 0x0120,
 	PPPOE_SERVICE_NAME_ERROR = 0x0201,
 	PPPOE_AC_SYSTEM_ERROR = 0x0202,
 	PPPOE_GENERIC_ERROR = 0x0203
@@ -83,6 +84,7 @@ static struct tok pppoetag2str[] = {
 	{ PPPOE_AC_COOKIE, "AC-Cookie" },
 	{ PPPOE_VENDOR, "Vendor-Specific" },
 	{ PPPOE_RELAY_SID, "Relay-Session-ID" },
+	{ PPPOE_MAX_PAYLOAD, "PPP-Max-Payload" },
 	{ PPPOE_SERVICE_NAME_ERROR, "Service-Name-Error" },
 	{ PPPOE_AC_SYSTEM_ERROR, "AC-System-Error" },
 	{ PPPOE_GENERIC_ERROR, "Generic-Error" },


### PR DESCRIPTION
Small two-line patch that decodes the optional PPP-Max-Payload PPPoE tag as defined in RFC 4638.
