### PR TITLE
Use SIGUSR1 to request info when SIGINFO is not defined

### DIFF
--- a/tcpdump.c
+++ b/tcpdump.c
@@ -87,6 +87,12 @@ extern int SIZE_BUF;
 #define NAME_MAX 255
 #endif
 
+#ifdef SIGINFO
+#define SIGNAL_REQ_INFO SIGINFO
+#elif SIGUSR1
+#define SIGNAL_REQ_INFO SIGUSR1
+#endif
+
 netdissect_options Gndo;
 netdissect_options *gndo = &Gndo;
 
@@ -119,7 +125,7 @@ static void ndo_error(netdissect_options *ndo, const char *fmt, ...)
      __attribute__ ((noreturn, format (printf, 2, 3)));
 static void ndo_warning(netdissect_options *ndo, const char *fmt, ...);
 
-#ifdef SIGINFO
+#ifdef SIGNAL_REQ_INFO
 RETSIGTYPE requestinfo(int);
 #endif
 
@@ -1349,13 +1355,13 @@ main(int argc, char **argv)
 		pcap_userdata = (u_char *)&printinfo;
 	}
 
-#ifdef SIGINFO
+#ifdef SIGNAL_REQ_INFO
 	/*
 	 * We can't get statistics when reading from a file rather
 	 * than capturing from a device.
 	 */
 	if (RFileName == NULL)
-		(void)setsignal(SIGINFO, requestinfo);
+		(void)setsignal(SIGNAL_REQ_INFO, requestinfo);
 #endif
 
 	if (vflag > 0 && WFileName) {
@@ -1844,7 +1850,7 @@ default_print(const u_char *bp, u_int length)
 	ndo_default_print(gndo, bp, length);
 }
 
-#ifdef SIGINFO
+#ifdef SIGNAL_REQ_INFO
 RETSIGTYPE requestinfo(int signo _U_)
 {
 	if (infodelay)


### PR DESCRIPTION
tcpdump can dump information about statistics when SIGINFO is signaled to the process.
This is useful to monitor number of packets that are currently captured / received / dropped.

On most Linux systems however, do not have SIGINFO signal defined.
By applying this patch, when SIGINFO is undefined but SIGUSR1 is available, tcpdump use SIGUSR1 as a signal to print the statistics, instead of SIGINFO.

This is the same way as GNU's dd implementation do; it dumps out how many bytes are copied when SIGUSR1 is signaled.
