### PR TITLE
LLDP: print packet protocol at all verbosity levels

### DIFF
--- a/print-lldp.c
+++ b/print-lldp.c
@@ -1184,9 +1184,7 @@ lldp_print(register const u_char *pptr, register u_int len) {
     tptr = pptr;
     tlen = len;
 
-    if (vflag) {
-        printf("LLDP, length %u", len);
-    }
+    printf("LLDP, length %u", len);
 
     while (tlen >= sizeof(tlv)) {
 


### PR DESCRIPTION
The LLDP printer doesn't show the packet protocol unless -v is used,
which results in pretty useless output lines where only the timestamp is
present. Make sure we include the default protocol+length output even in
default mode.
