### PR TITLE
Proposed changes to addrtoname.c and tcpdump.c (malloc/calloc sanity checks)

### DIFF
--- a/addrtoname.c
+++ b/addrtoname.c
@@ -381,6 +381,9 @@ lookup_bytestring(register const u_char *bs, const unsigned int nlen)
 	tp->e_addr2 = k;
 
 	tp->e_bs = (u_char *) calloc(1, nlen + 1);
+	if (tp->e_bs == NULL)
+		error("lookup_bytestring: calloc");
+		
 	memcpy(tp->e_bs, bs, nlen);
 	tp->e_nxt = (struct enamemem *)calloc(1, sizeof(*tp));
 	if (tp->e_nxt == NULL)

--- a/tcpdump.c
+++ b/tcpdump.c
@@ -589,7 +589,9 @@ static void
 MakeFilename(char *buffer, char *orig_name, int cnt, int max_chars)
 {
         char *filename = malloc(NAME_MAX + 1);
-
+		if (filename == NULL) /* didn't get memory requested	*/
+			error("MakeFilename: malloc");
+			
         /* Process with strftime if Gflag is set. */
         if (Gflag != 0) {
           struct tm *local_tm;


### PR DESCRIPTION
In addrtoname.c, the submitted patch adds a check for the return value from calloc in function
'lookup_bytestring'.

In tcpdump.c, the submitted patch adds a check for the return value from malloc in function
'MakeFilename'.
