### PR TITLE
.gitignore: add failure-outputs.txt 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ tcpdump
 tcpdump.1
 tcpdump-*.tar.gz
 version.c
+failure-outputs.txt


### PR DESCRIPTION
This pull request add the file name "failure-outputs.txt" (output of make check) in .gitignore
