### PR TITLE
Fix SIGINT with multiple file reading.

### DIFF
--- a/tcpdump.c
+++ b/tcpdump.c
@@ -1545,6 +1545,14 @@ main(int argc, char **argv)
 			}
 			(void)fflush(stdout);
 		}
+                if (status == -2) {
+			/*
+			 * We got interrupted. If we are reading multiple
+			 * files (via -V) set these so that we stop.
+			 */
+			VFileName = NULL;
+			ret = NULL;
+		}
 		if (status == -1) {
 			/*
 			 * Error.  Report it.


### PR DESCRIPTION
Prior to this if pcap_breakloop() is called in cleanup() while reading multiple files (via -V) the code would fall through and open the next file in the list. With this change the list is cut short and the program exits normally.
