### PR TITLE
 Add some warnings (-Wunused -Wdeclaration-after-statement) in devel mode

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -821,7 +821,7 @@ AC_DEFUN(AC_LBL_DEVEL,
 			    fi
 			    $1="$$1 -Wall"
 			    if test $ac_cv_lbl_gcc_vers -gt 1 ; then
-				    $1="$$1 -Wmissing-prototypes -Wstrict-prototypes -Wwrite-strings -Wpointer-arith -W"
+				    $1="$$1 -Wmissing-prototypes -Wstrict-prototypes -Wwrite-strings -Wpointer-arith -Wunused -Wdeclaration-after-statement -W"
 			    fi
 		    fi
 	    else

--- a/configure
+++ b/configure
@@ -7122,7 +7122,7 @@ rm -f os-proto.h
 			    fi
 			    V_CCOPT="$V_CCOPT -Wall"
 			    if test $ac_cv_lbl_gcc_vers -gt 1 ; then
-				    V_CCOPT="$V_CCOPT -Wmissing-prototypes -Wstrict-prototypes -Wwrite-strings -Wpointer-arith -W"
+				    V_CCOPT="$V_CCOPT -Wmissing-prototypes -Wstrict-prototypes -Wwrite-strings -Wpointer-arith -Wunused -Wdeclaration-after-statement -W"
 			    fi
 		    fi
 	    else


### PR DESCRIPTION
to get:
warning: unused parameter 'xxx'
warning: ISO C90 forbids mixed declarations and code
