### PR TITLE
vxlan: use IANA assigned port

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -60,6 +60,7 @@ Additional people who have contributed patches:
     Fang Wang                     <fangwang at sourceforge dot net>
     Florent Drouin                <Florent dot Drouin at alcatel-lucent dot fr>
     Florian Forster               <octo at verplant dot org>
+    Francesco Fondelli            <francesco dot fondelli at gmail dot com>
     Francis Dupont                <Francis dot Dupont at enst-bretagne dot fr>
     Francisco Matias Cuenca-Acuna <mcuenca at george dot rutgers dot edu>
     Francois-Xavier Le Bail       <fx dot lebail at yahoo dot com>

--- a/print-udp.c
+++ b/print-udp.c
@@ -670,6 +670,8 @@ udp_print(register const u_char *bp, u_int length,
 			syslog_print((const u_char *)(up + 1), length);
                 else if (ISPORT(OTV_PORT))
 			otv_print((const u_char *)(up + 1), length);
+                else if (ISPORT(VXLAN_PORT))
+			vxlan_print((const u_char *)(up + 1), length);
 		else
 			(void)printf("UDP, length %u",
 			    (u_int32_t)(ulen - sizeof(*up)));

--- a/udp.h
+++ b/udp.h
@@ -86,6 +86,7 @@ struct udphdr {
 #define LWAPP_DATA_PORT         12222 /* draft-ohara-capwap-lwapp-04.txt */
 #define LWAPP_CONTROL_PORT      12223 /* draft-ohara-capwap-lwapp-04.txt */
 #define OTV_PORT                8472  /* draft-hasmit-otv-04 */
+#define VXLAN_PORT              4789  /* draft-mahalingam-dutt-dcops-vxlan-04 */
 
 #ifdef INET6
 #define RIPNG_PORT 521		/*XXX*/


### PR DESCRIPTION
IANA (http://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.txt) has assigned an official port for VXLAN (4789).  tcpdump uses this by default but we keep the -T vxlan option as well (e.g. Linux is allowing different ports).
