### PR TITLE
IP packet information printing from NFLOG packet

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -84,7 +84,8 @@ CSRC =	addrtoname.c af.c checksum.c cpack.c gmpls.c oui.c gmt2local.c ipproto.c 
 	print-l2tp.c print-lane.c print-ldp.c print-lldp.c print-llc.c \
         print-lmp.c print-lspping.c print-lwapp.c \
 	print-lwres.c print-mobile.c print-mpcp.c print-mpls.c print-mptcp.c print-msdp.c \
-	print-msnlb.c print-nfs.c print-ntp.c print-null.c print-olsr.c print-ospf.c \
+	print-msnlb.c print-nfs.c print-ntp.c print-null.c print-nflog.c \
+	print-olsr.c print-ospf.c \
 	print-pgm.c print-pim.c \
 	print-ppi.c print-ppp.c print-pppoe.c print-pptp.c \
 	print-radius.c print-raw.c print-rip.c print-rpki-rtr.c print-rrcp.c print-rsvp.c \

--- a/netdissect.h
+++ b/netdissect.h
@@ -473,6 +473,8 @@ extern void pptp_print(netdissect_options *,const u_char *, u_int);
 extern u_int ipnet_if_print(netdissect_options *,const struct pcap_pkthdr *, const u_char *);
 extern u_int ppi_if_print(netdissect_options *,const struct pcap_pkthdr *, const u_char *);
 
+extern u_int nflog_if_print(netdissect_options *,const struct pcap_pkthdr *, const u_char *);
+
 extern u_int ieee802_15_4_if_print(netdissect_options *,const struct pcap_pkthdr *, const u_char *);
 
 #ifdef INET6

--- a/print-nflog.c
+++ b/print-nflog.c
@@ -1,0 +1,38 @@
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <tcpdump-stdinc.h>
+
+#include <stdio.h>
+#include <pcap.h>
+
+#include "netdissect.h"
+#include "interface.h"
+
+#ifdef DLT_NFLOG
+
+static void
+nflog_print(struct netdissect_options *ndo, const u_char *p, u_int length, u_int caplen)
+{
+    ip_print(ndo, p, length);
+    return;
+}
+
+u_int
+nflog_if_print(struct netdissect_options *ndo,
+               const struct pcap_pkthdr *h, const u_char *p)
+{
+    int j = 0;
+
+    /* Discard NFLOG header */
+    for (j = 0; j < 104; j++) {
+        *p++;
+    }
+
+	nflog_print(ndo, p, h->len - 104, h->caplen - 104);
+
+	return 0;
+}
+
+#endif /* DLT_NFLOG */

--- a/tcpdump.c
+++ b/tcpdump.c
@@ -312,6 +312,9 @@ static struct printer printers[] = {
 };
 
 static struct ndo_printer ndo_printers[] = {
+#ifdef DLT_NFLOG
+	{ nflog_if_print,	DLT_NFLOG},
+#endif
 	{ ether_if_print,	DLT_EN10MB },
 #ifdef DLT_IPNET
 	{ ipnet_if_print,	DLT_IPNET },


### PR DESCRIPTION
Added IP packet information printing on stdout after discarding NFLOG header. 
